### PR TITLE
Use virtual keyboard as fallback keyboard type

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To display programs within the X-Server demo app you need to set the DISPLAY env
 
 ### Build
 
-#### Gardle
+#### Gradle
 
 This project uses gradle build system, so if you don't want to mess with Android Studio you can just
  open console at project's root folder and type `./gradlew build`. Generated APK can be found under

--- a/library/src/main/java/au/com/darkside/xserver/Keyboard.java
+++ b/library/src/main/java/au/com/darkside/xserver/Keyboard.java
@@ -30,7 +30,7 @@ public class Keyboard {
 		KeyEvent.KEYCODE_META_LEFT, KeyEvent.KEYCODE_META_RIGHT, 0, 0, 0, 0, 0, 0, // 40
 		0, 0, 0, 0, 0, 0, 0, 0  // 80
     };
-    
+
     private static final int DefaultBellPercent = 50;
     private int _bellPercent = DefaultBellPercent;
     private static final int DefaultBellPitch = 400;
@@ -61,6 +61,14 @@ public class Keyboard {
         int idx = 0;
         int[] map = new int[256 * kpk];
         KeyCharacterMap kcm = KeyCharacterMap.load(KeyCharacterMap.FULL);
+        // Some devices don't have keyboard with full type, and the Android OS uses
+        // the KeyCharacterMap.BUILT_IN_KEYBOARD (value is 0) as the fallback keyboard
+        // type. If the phone/tablet doesn't have built in keyboard, the returned
+        // KeyCharacterMap is empty, and it will causes the ArrayOutOfBounds exception
+        // when initializing keyboard mapping.
+        if (kcm.getKeyboardType() != KeyCharacterMap.FULL) {
+            kcm = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
+        }
 
         for (int i = 0; i < 256; i++) {
             int c1 = kcm.get(i, 0);
@@ -357,7 +365,7 @@ public class Keyboard {
 						int offset = keycode / 8;
 						byte mask = (byte) (1 << (keycode & 7));
 						if ((_keymap[offset] & mask) == mask)
-							status = 2; // If a modifier is pressed 
+							status = 2; // If a modifier is pressed
 						modifierMapping[i] = (byte) (keycode - diff);
 					}
 
@@ -417,7 +425,7 @@ public class Keyboard {
 
     /**
      * Get modifier state.
-     * 
+     *
      * @return Modifier state According to pressed keys (keymap) and modifiermapping.
      */
     public int getState() {


### PR DESCRIPTION
Some devices don't have keyboard with full type, and the Android OS uses
the `KeyCharacterMap.BUILT_IN_KEYBOARD` (value is 0) as the fallback keyboard
type. If the phone/tablet doesn't have built in keyboard, the returned
`KeyCharacterMap` is empty, and it will causes the `ArrayOutOfBounds` exception
 when initializing keyboard mapping. The problem can be reproduced on the official
emulator.  So this CL adds `KeyboardCharacterMap.VIRTUAL_KEYBOARD` as
the fallback keyboard type, if the phone/tablet doesn't have `FULL` keyboard.